### PR TITLE
Add ROCm libs at build to enable AMD GPU detection

### DIFF
--- a/schedmd/slurm/24.11/docker-bake.hcl
+++ b/schedmd/slurm/24.11/docker-bake.hcl
@@ -13,6 +13,10 @@ variable "SLURM_VERSION" {
   default = "24.11.4"
 }
 
+variable "ROCM_VERSION" {
+  default = "6.3.4"
+}
+
 function "format_name" {
   params = [stage, version, flavor]
   // Remove [:punct:] from string before joining elements
@@ -56,6 +60,7 @@ target "_default" {
   }
   args = {
     SLURM_VERSION = "${SLURM_VERSION}"
+    ROCM_VERSION = "${ROCM_VERSION}"
     DEBUG = "${DEBUG}"
   }
   target = stage

--- a/schedmd/slurm/24.11/ubuntu24.04/Dockerfile
+++ b/schedmd/slurm/24.11/ubuntu24.04/Dockerfile
@@ -17,6 +17,11 @@ ARG DEBIAN_FRONTEND=noninteractive
 ARG SLURM_VERSION
 ENV SLURM_VERSION=${SLURM_VERSION}
 
+ARG ROCM_VERSION
+ENV ROCM_VERSION=${ROCM_VERSION} \
+    ROCBLAS_DIR=/opt/rocm-${ROCM_VERSION}/lib/rocblas \
+    ROCM_DIR=/opt/rocm-${ROCM_VERSION}
+
 USER root
 WORKDIR /tmp/
 
@@ -30,6 +35,10 @@ apt-get -qq update
 apt-get -qq -y upgrade
 apt-get -qq -y install --no-install-recommends \
   build-essential fakeroot devscripts equivs curl
+curl -fsSL https://repo.radeon.com/rocm/rocm.gpg.key | gpg --dearmor > /etc/apt/keyrings/rocm.gpg
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/${ROCM_VERSION} noble main" >> /etc/apt/sources.list.d/rocm.list
+apt-get -qq update
+apt-get install -qq -y --no-install-recommends rocm-smi-lib
 ## Download
 SLURM_DIR="slurm-${SLURM_VERSION}"
 mkdir -p $SLURM_DIR


### PR DESCRIPTION
Built slurmd container image has `gpu_rsmi.so` library present
```
root@44b74e940b4b:/tmp# ls -l /usr/lib/x86_64-linux-gnu/slurm/gpu*.so
 -rw-r--r-- 1 root root 14592 Jul  5  2024 /usr/lib/x86_64-linux-gnu/slurm/gpu_generic.so
 -rw-r--r-- 1 root root 14728 Jul  5  2024 /usr/lib/x86_64-linux-gnu/slurm/gpu_nrt.so
 -rw-r--r-- 1 root root 23016 Jul  5  2024 /usr/lib/x86_64-linux-gnu/slurm/gpu_nvidia.so
 -rw-r--r-- 1 root root 35512 Jul  5  2024 /usr/lib/x86_64-linux-gnu/slurm/gpu_rsmi.so
```