### PR TITLE
Add ContainerSSH Agent to login image

### DIFF
--- a/schedmd/slurm/24.11/ubuntu24.04/Dockerfile
+++ b/schedmd/slurm/24.11/ubuntu24.04/Dockerfile
@@ -502,6 +502,19 @@ apt-get -qq -y install \
 
 # Install lmod
 apt-get -qq -y install --no-install-recommends ./lmod_[0-9]*.deb
+# Install ContainerSSH Agent
+apt-get update
+apt-get -qq -y install --no-install-recommends \
+  apt-transport-https \
+  ca-certificates \
+  curl \
+  gnupg-agent \
+  software-properties-common
+curl -fsSL https://packages.containerssh.io/debian/gpg | apt-key add -
+add-apt-repository  "deb [arch=amd64] https://packages.containerssh.io/debian ./"
+apt-get -qq update
+apt-get -qq -y install --no-install-recommends containerssh-agent
+# Clean up
 rm *.deb && apt-get clean && rm -rf /var/lib/apt/lists/*
 # Configure
 mkdir -p /etc/authselect


### PR DESCRIPTION
Add ContainerSSH agent to login container image

Followed steps [ContainerSSH Docs](https://containerssh.io/v0.5/reference/image/#__tabbed_1_2)